### PR TITLE
Add codecov reporting as a github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       working-directory: ./apolloschurchapp
 
     - name: Generate Codecov
-    - run: yarn lerna run codecov
+      run: yarn lerna run codecov
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       working-directory: ./apolloschurchapp
 
     - name: Codecov
-    - uses: codecov/codecov-action@v1
+      run: yarn lerna run codecov
+      uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-      run: yarn lerna run codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: codecov/codecov-action@v1
     - name: Setup test environment with node ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -43,3 +44,6 @@ jobs:
     - name: Test
       run: yarn test --forceExit
       working-directory: ./apolloschurchapp
+
+    - name: Codecov
+      run: yarn lerna run codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - master
-      paths-ignore:
+    paths-ignore:
       - '**.md'
   pull_request:
     types: [synchronize]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,12 @@ on:
   push:
     branches:
       - master
+      paths-ignore:
+      - '**.md'
   pull_request:
     types: [synchronize]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   tests_ci:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    types: [synchronize]
-    paths-ignore:
-      - '**.md'
+    types: [opened, reopened, synchronize]
 
 jobs:
   tests_ci:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Tests CI
 
 on:
@@ -48,8 +45,10 @@ jobs:
       run: yarn test --forceExit
       working-directory: ./apolloschurchapp
 
-    - name: Codecov
-      run: yarn lerna run codecov
+    - name: Generate Codecov
+    - run: yarn lerna run codecov
+
+    - name: Upload to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: codecov/codecov-action@v1
     - name: Setup test environment with node ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -50,4 +49,7 @@ jobs:
       working-directory: ./apolloschurchapp
 
     - name: Codecov
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
       run: yarn lerna run codecov


### PR DESCRIPTION
Add codecov reporting. I think this was all I needed. Not sure if it's running twice or if I should be doing this a different way. I might be able to remove the `yarn lerna run codecov` by simply adding a `codecov.yml` but I'm not sure.