### PR TITLE
Adds LiveConsumer support to Vertical/Horizontal card list

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -154,8 +154,13 @@ HOME_FEATURES:
     subtitle: Continue
     type: HorizontalCardList
   - title: RECOMMENDED
-    algorithms: [SERMON_CHILDREN]
     subtitle: For Him
+    algorithms:
+      - type: CONTENT_CHANNEL
+        arguments:
+          contentChannelId: 5
+          limit: 1
+      - type: SERMON_CHILDREN
     type: VerticalCardList
   - title: BULLETIN
     subtitle: What's happening at apollos?

--- a/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
+++ b/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
@@ -154,6 +154,7 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
             action="READ_CONTENT"
             id="WeekendContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",
@@ -708,6 +709,7 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
             action="READ_CONTENT"
             id="DevotionalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",
@@ -1054,6 +1056,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             channelType=""
             id="fakeId0"
             inHorizontalList={true}
+            isLive={false}
             isLoading={true}
             style={
               Object {
@@ -1253,6 +1256,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             channelType=""
             id="fakeId1"
             inHorizontalList={true}
+            isLive={false}
             isLoading={true}
             style={
               Object {
@@ -1452,6 +1456,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             channelType=""
             id="fakeId2"
             inHorizontalList={true}
+            isLive={false}
             isLoading={true}
             style={
               Object {
@@ -1651,6 +1656,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             channelType=""
             id="fakeId3"
             inHorizontalList={true}
+            isLive={false}
             isLoading={true}
             style={
               Object {
@@ -1850,6 +1856,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             channelType=""
             id="fakeId4"
             inHorizontalList={true}
+            isLive={false}
             isLoading={true}
             style={
               Object {
@@ -2186,6 +2193,7 @@ exports[`The HorizontalCardListFeature component should render a section title 1
             action="READ_CONTENT"
             id="WeekendContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",
@@ -2740,6 +2748,7 @@ exports[`The HorizontalCardListFeature component should render a section title 1
             action="READ_CONTENT"
             id="DevotionalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",
@@ -3071,6 +3080,7 @@ exports[`The HorizontalCardListFeature component should render with a section su
             action="READ_CONTENT"
             id="WeekendContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",
@@ -3625,6 +3635,7 @@ exports[`The HorizontalCardListFeature component should render with a section su
             action="READ_CONTENT"
             id="DevotionalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae"
             inHorizontalList={true}
+            isLive={false}
             style={
               Object {
                 "backgroundColor": "#303030",

--- a/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
@@ -58,10 +58,14 @@ class HorizontalCardListFeature extends PureComponent {
     <LiveConsumer contentId={item.id}>
       {(liveStream) => {
         const isLive = !!(liveStream && liveStream.isLive);
-
+        const labelText = isLive ? 'Live' : labelText;
         return (
           <TouchableScale onPress={() => this.props.onPressItem(item)}>
-            {horizontalContentCardComponentMapper({ isLive, ...item })}
+            {horizontalContentCardComponentMapper({
+              isLive,
+              ...item,
+              labelText,
+            })}
           </TouchableScale>
         );
       }}

--- a/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
@@ -58,7 +58,7 @@ class HorizontalCardListFeature extends PureComponent {
     <LiveConsumer contentId={item.id}>
       {(liveStream) => {
         const isLive = !!(liveStream && liveStream.isLive);
-        const labelText = isLive ? 'Live' : labelText;
+        const labelText = isLive ? 'Live' : item.labelText;
         return (
           <TouchableScale onPress={() => this.props.onPressItem(item)}>
             {horizontalContentCardComponentMapper({

--- a/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/HorizontalCardListFeature/index.js
@@ -11,7 +11,10 @@ import {
   TouchableScale,
   withIsLoading,
 } from '@apollosproject/ui-kit';
-import { horizontalContentCardComponentMapper } from '@apollosproject/ui-connected';
+import {
+  horizontalContentCardComponentMapper,
+  LiveConsumer,
+} from '@apollosproject/ui-connected';
 
 const Title = styled(
   ({ theme }) => ({
@@ -52,9 +55,17 @@ class HorizontalCardListFeature extends PureComponent {
   keyExtractor = (item) => item && item.id;
 
   renderItem = ({ item }) => (
-    <TouchableScale onPress={() => this.props.onPressItem(item)}>
-      {horizontalContentCardComponentMapper({ ...item })}
-    </TouchableScale>
+    <LiveConsumer contentId={item.id}>
+      {(liveStream) => {
+        const isLive = !!(liveStream && liveStream.isLive);
+
+        return (
+          <TouchableScale onPress={() => this.props.onPressItem(item)}>
+            {horizontalContentCardComponentMapper({ isLive, ...item })}
+          </TouchableScale>
+        );
+      }}
+    </LiveConsumer>
   );
 
   render() {

--- a/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
@@ -10,7 +10,10 @@ import {
   styled,
   withIsLoading,
 } from '@apollosproject/ui-kit';
-import { contentCardComponentMapper } from '@apollosproject/ui-connected';
+import {
+  contentCardComponentMapper,
+  LiveConsumer,
+} from '@apollosproject/ui-connected';
 
 const Title = styled(
   ({ theme }) => ({
@@ -54,6 +57,19 @@ const Header = styled(({ theme }) => ({
 //   return content;
 // };
 
+const ListItemComponent = ({ contentId, ...args }) => (
+  <LiveConsumer contentId={contentId}>
+    {(liveStream) => {
+      const isLive = !!(liveStream && liveStream.isLive);
+      return contentCardComponentMapper({ isLive, contentId, ...args });
+    }}
+  </LiveConsumer>
+);
+
+ListItemComponent.propTypes = {
+  contentId: PropTypes.string,
+};
+
 const VerticalCardListFeature = memo(
   ({ cards, isLoading, listKey, onPressItem, subtitle, title }) => (
     <View>
@@ -65,7 +81,7 @@ const VerticalCardListFeature = memo(
       </Header>
       <FeedView
         onPressItem={onPressItem}
-        ListItemComponent={contentCardComponentMapper}
+        ListItemComponent={ListItemComponent}
         content={cards} // {getContent({ cards, isLoading })}
         isLoading={isLoading}
         listKey={listKey}

--- a/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import {
   FeedView,
@@ -57,11 +58,12 @@ const Header = styled(({ theme }) => ({
 //   return content;
 // };
 
-const ListItemComponent = ({ contentId, ...args }) => (
+const ListItemComponent = ({ contentId, ...item }) => (
   <LiveConsumer contentId={contentId}>
     {(liveStream) => {
       const isLive = !!(liveStream && liveStream.isLive);
-      return contentCardComponentMapper({ isLive, contentId, ...args });
+      const labelText = isLive ? 'Live' : item.labelText;
+      return contentCardComponentMapper({ isLive, ...item, labelText });
     }}
   </LiveConsumer>
 );

--- a/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/VerticalCardListFeature/index.js
@@ -1,7 +1,6 @@
 import React, { memo } from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 
 import {
   FeedView,

--- a/apolloschurchapp/src/tabs/home/Features/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/index.js
@@ -171,6 +171,7 @@ const Features = memo(({ navigation }) => (
                       : {}),
                     coverImage: get(card, 'coverImage.sources', undefined),
                     __typename: card.relatedNode.__typename,
+                    id: card.relatedNode.id,
                   }))}
                   isLoading={loading}
                   listKey={id}

--- a/apolloschurchapp/src/tabs/home/Features/index.js
+++ b/apolloschurchapp/src/tabs/home/Features/index.js
@@ -171,7 +171,6 @@ const Features = memo(({ navigation }) => (
                       : {}),
                     coverImage: get(card, 'coverImage.sources', undefined),
                     __typename: card.relatedNode.__typename,
-                    id: card.relatedNode.id,
                   }))}
                   isLoading={loading}
                   listKey={id}


### PR DESCRIPTION
This brings us to feature parity with the content card connected. Plus more! Huzzah! 

I swapped the default feed around a bit so you'll be able to see the "Spur One Another" item go live. It goes live at the bottom half of every hour. 

