### PR TITLE
Browser Component for Spotify Playlists

### DIFF
--- a/apolloschurchapp/ios/Podfile.lock
+++ b/apolloschurchapp/ios/Podfile.lock
@@ -87,7 +87,7 @@ PODS:
     - react-native-video/Video (= 5.0.2)
   - react-native-video/Video (5.0.2):
     - React
-  - react-native-webview (7.6.0):
+  - react-native-webview (9.3.0):
     - React
   - React-RCTActionSheet (0.60.5):
     - React-Core (= 0.60.5)
@@ -304,7 +304,7 @@ SPEC CHECKSUMS:
   react-native-safari-view: 955d7160d159241b8e9395d12d10ea0ef863dcdd
   react-native-safe-area-context: e380a6f783ccaec848e2f3cc8eb205a62362950d
   react-native-video: d01ed7ff1e38fa7dcc6c15c94cf505e661b7bfd0
-  react-native-webview: db4682f1698ab4b17a5e88f951031d203ff8aea8
+  react-native-webview: 60d883f994e96a560756c14592552e02a06d604d
   React-RCTActionSheet: b0f1ea83f4bf75fb966eae9bfc47b78c8d3efd90
   React-RCTAnimation: 359ba1b5690b1e87cc173558a78e82d35919333e
   React-RCTBlob: 5e2b55f76e9a1c7ae52b826923502ddc3238df24

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -108,7 +108,7 @@
     "react-native-svg": "^9.4.0",
     "react-native-video": "^5.0.0",
     "react-native-video-controls": "2.2.3",
-    "react-native-webview": "^7.0.0",
+    "react-native-webview": "9.3.0",
     "react-navigation": "^3.11.0",
     "recompose": "^0.30.0",
     "rn-fetch-blob": "^0.10.16",

--- a/apolloschurchapp/src/ui/Browser/Browser.stories.js
+++ b/apolloschurchapp/src/ui/Browser/Browser.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@apollosproject/ui-storybook';
+
+import Browser from '.';
+
+const navigation = {
+  navigate: () => {},
+  pop: () => {},
+};
+
+storiesOf('Browser', module)
+  .add('default', () => (
+    <Browser
+      url={
+        'https://open.spotify.com/embed/user/spotify/playlist/37i9dQZF1DWWvHBEQLnV1N'
+      }
+      navigation={navigation}
+    />
+  ))
+  .add('modal', () => (
+    <Browser
+      url={
+        'https://open.spotify.com/embed/user/spotify/playlist/37i9dQZF1DWWvHBEQLnV1N'
+      }
+      modal
+      navigation={navigation}
+    />
+  ));

--- a/apolloschurchapp/src/ui/Browser/index.js
+++ b/apolloschurchapp/src/ui/Browser/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ModalView, styled } from '@apollosproject/ui-kit';
+import { WebView } from 'react-native-webview';
+import { SafeAreaView } from 'react-navigation';
+
+const FlexedSafeAreaView = styled(({ theme }) => ({
+  flex: 1,
+  backgroundColor: theme.colors.black,
+}))(SafeAreaView);
+
+const Browser = ({ url, cookie, modal, navigation }) => {
+  if (modal) {
+    return (
+      <ModalView navigation={navigation} onClose={() => navigation.pop()}>
+        <FlexedSafeAreaView>
+          <WebView source={{ uri: url, headers: { Cookie: cookie } }} />
+        </FlexedSafeAreaView>
+      </ModalView>
+    );
+  }
+  return <WebView source={{ uri: url, headers: { Cookie: cookie } }} />;
+};
+
+Browser.propTypes = {
+  url: PropTypes.string.isRequired,
+  cookie: PropTypes.string,
+  modal: PropTypes.bool.isRequired,
+};
+
+export default Browser;

--- a/apolloschurchapp/src/ui/Browser/index.js
+++ b/apolloschurchapp/src/ui/Browser/index.js
@@ -9,22 +9,21 @@ const FlexedSafeAreaView = styled(({ theme }) => ({
   backgroundColor: theme.colors.black,
 }))(SafeAreaView);
 
-const Browser = ({ url, cookie, modal, navigation }) => {
+const Browser = ({ url, modal, navigation }) => {
   if (modal) {
     return (
       <ModalView navigation={navigation} onClose={() => navigation.pop()}>
         <FlexedSafeAreaView>
-          <WebView source={{ uri: url, headers: { Cookie: cookie } }} />
+          <WebView source={{ uri: url }} />
         </FlexedSafeAreaView>
       </ModalView>
     );
   }
-  return <WebView source={{ uri: url, headers: { Cookie: cookie } }} />;
+  return <WebView source={{ uri: url }} />;
 };
 
 Browser.propTypes = {
   url: PropTypes.string.isRequired,
-  cookie: PropTypes.string,
   modal: PropTypes.bool.isRequired,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14351,10 +14351,10 @@ react-native-video@^5.0.0:
     prop-types "^15.5.10"
     shaka-player "^2.4.4"
 
-react-native-webview@^7.0.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-7.6.0.tgz#6bae76430200be5e5ead7d986af2fa341b650186"
-  integrity sha512-IQWtIpCTYb4dTshAJO3hMM9Ms5T6KRpk6qWqgBTGMdmgeEvSxWz9l7Og1ALhb7T7NoAnPy8w/dQmD9LlbGGs5g==
+react-native-webview@9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-9.3.0.tgz#f0a7d76bae288c78f63e7dad66bca7ed1e6c9386"
+  integrity sha512-mgRTMXELSULf9y7PjJiGO5pZs9tFbXI4fG9zK3rpCR9R9/bJwVdvLW6yIbLZ+8m36Upu9Go/Qsi+42n4UGZMkQ==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
This is similar to `user-web-browser` component but without the need for rock cookie. This comes from the need to embed a Spotify playlist in an app. There are two stories one embedding the playlist in a modal and one just in a WebView.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-27 at 16 24 14](https://user-images.githubusercontent.com/2528817/80423029-d3f0a900-88a4-11ea-933b-9af86ede78c3.png)

 It seems that we can only play 30 seconds from each song in the playlist. If the user whats to listen to the complete playlist they will need to use the Spotify app.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-27 at 16 23 35](https://user-images.githubusercontent.com/2528817/80423014-cd623180-88a4-11ea-955e-24cc8b7fa200.png)
