### PR TITLE
Fix border bug on view all in discover feed

### DIFF
--- a/apolloschurchapp/src/content-feed/index.js
+++ b/apolloschurchapp/src/content-feed/index.js
@@ -21,7 +21,11 @@ class ContentFeed extends PureComponent {
     const itemTitle = navigation.getParam('itemTitle', 'Content Channel');
     return {
       title: itemTitle,
-      headerStyle: { backgroundColor: screenProps.headerBackgroundColor },
+      headerStyle: {
+        backgroundColor: screenProps.headerBackgroundColor,
+        borderBottomWidth: 0,
+        elevation: 0,
+      },
     };
   };
 

--- a/apolloschurchapp/src/testing-control-panel/index.js
+++ b/apolloschurchapp/src/testing-control-panel/index.js
@@ -5,8 +5,13 @@ import { UserWebBrowserConsumer } from '../user-web-browser';
 import TouchableCell from './TouchableCell';
 
 export default class TestingControlPanel extends PureComponent {
-  static navigationOptions = () => ({
+  static navigationOptions = ({ screenProps }) => ({
     title: 'Testing Control Panel',
+    headerStyle: {
+      backgroundColor: screenProps.headerBackgroundColor,
+      borderBottomWidth: 0,
+      elevation: 0,
+    },
   });
 
   render() {


### PR DESCRIPTION
In dark theme there is no longer a white border on the header when you click `view all`
![image](https://user-images.githubusercontent.com/2528817/83681598-43467080-a5a8-11ea-957b-579df98f9919.png)
