### PR TITLE
Deploys Android to Internal, not Alpha

### DIFF
--- a/apolloschurchapp/fastlane/Fastfile
+++ b/apolloschurchapp/fastlane/Fastfile
@@ -38,6 +38,6 @@ platform :android do
   desc "Deploy a new version to the Google Play"
   lane :deploy do
     gradle(project_dir: "android", task: "clean assembleRelease")
-    upload_to_play_store(track: "alpha")
+    upload_to_play_store(track: "internal")
   end
 end


### PR DESCRIPTION
**IMPORTANT: Unless you are doing a release, you should be pointing your PR at the `develop` branch. `master` should not rely on code not published in `npm`**