### PR TITLE
Triggers CI for all branches

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,6 @@
 name: Linting
 
-on:
-  pull_request:
-    branches: [ master ]
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,8 +1,6 @@
 name: Unit Tests
 
-on:
-  pull_request:
-    branches: [ master ]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**