### PR TITLE
Authorizes Actions to Deploy

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -25,5 +25,6 @@ jobs:
 
     - name: Fastlane Deploy
       run: |
+        export MATCH_GIT_BASIC_AUTHORIZATION=${{ secrets.GITHUB_TOKEN }}
         cd apolloschurchapp
         bundle exec fastlane ios deploy


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**