### PR TITLE
Changes Deploy Job Name

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  deploy:
 
     runs-on: macos-latest
 


### PR DESCRIPTION
This is why all the other PRs are being held up. Because the deploy is failing and "build" is required to pass.


**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**