### PR TITLE
Changed to HTTPS Match URL

### DIFF
--- a/apolloschurchapp/fastlane/Matchfile
+++ b/apolloschurchapp/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("git@github.com:ApollosProject/certificates.git")
+git_url("https://github.com/ApollosProject/certificates")
 
 storage_mode("git")
 


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**