### PR TITLE
Disable fetch cache

### DIFF
--- a/apolloschurchapp/src/client/httpLink.js
+++ b/apolloschurchapp/src/client/httpLink.js
@@ -20,5 +20,11 @@ export default split(
   createHttpLink({
     uri,
     useGETForQueries: true,
+    headers: {
+      // We can safely send these headers.
+      // Fastly does not currently respect no-store or no-cache directives. Including either or both of these in a Cache-Control header has no effect on Fastly's caching decision
+      // https://docs.fastly.com/en/guides/configuring-caching#do-not-cache
+      'Cache-Control': 'no-cache, no-store',
+    },
   })
 );


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**

If we want caching, we should use Fastly, Apollo's in memory cache, or a server side caching solution. The built in fetch cache is one too many variables to maintain firm control, over what ends up in the cache.   