### PR TITLE
Changes Heroku Deploy Job name

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**