### PR TITLE
Install Keychain on CI for iOS deploy

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Install Dependencies
       run: yarn
 
+    - name: Install Keychain
+      uses: sinoru/actions-setup-keychain@v1.0
+
     - name: Fastlane Deploy
       run: |
         cd apolloschurchapp


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**