### PR TITLE
Generate Coverage reports

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**