### PR TITLE
Fixes Heroku Deploy

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,8 +13,7 @@ jobs:
 
       # heroku only uses yarn if there's a yarn.lock file
       - name: Use Yarn
-        run: cp ../yarn.lock yarn.lock
-        working-directory: apollos-church-api
+        run: cp yarn.lock apollos-church-api/yarn.lock
 
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.5.6

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # heroku only uses yarn if there's a yarn.lock file
+      - name: Use Yarn
+        run: touch apollos-church-api/yarn.lock
+
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.5.6
         with:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,7 +13,8 @@ jobs:
 
       # heroku only uses yarn if there's a yarn.lock file
       - name: Use Yarn
-        run: touch apollos-church-api/yarn.lock
+        run: touch yarn.lock
+        working-directory: apollos-church-api
 
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.5.6

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,7 +13,7 @@ jobs:
 
       # heroku only uses yarn if there's a yarn.lock file
       - name: Use Yarn
-        run: touch yarn.lock
+        cp ../yarn.lock yarn.lock
         working-directory: apollos-church-api
 
       - name: Deploy to Heroku

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,7 +13,7 @@ jobs:
 
       # heroku only uses yarn if there's a yarn.lock file
       - name: Use Yarn
-        cp ../yarn.lock yarn.lock
+        run: cp ../yarn.lock yarn.lock
         working-directory: apollos-church-api
 
       - name: Deploy to Heroku

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ heroku login
 Create your app and upload to Heroku.
 
 ```
-heroku create apollos-api -s container
+heroku create apollos-api
 git push heroku master
 ```
 

--- a/apollos-church-api/package.json
+++ b/apollos-church-api/package.json
@@ -64,6 +64,6 @@
     "eslint-plugin-jest": "^21.15.2",
     "eslint-plugin-prettier": "^2.6.0",
     "linkemon": "^0.1.1",
-    "nodemon": "^2.0.2"
+    "nodemon": "1.18.7"
   }
 }


### PR DESCRIPTION
This fixes a couple of Heroku deploy problems:
- `linkemon` has a peer dep of `nodemon` v1
- Heroku only uses `yarn` if there's a `yarn.lock` file so I added a fake one that _should_ be regen'd
