### PR TITLE
fix: Don't error when formatting errors in dev mode.

### DIFF
--- a/apollos-church-api/src/server.js
+++ b/apollos-church-api/src/server.js
@@ -46,7 +46,7 @@ const apolloServer = new ApolloServer({
   extensions,
   plugins: [new BugsnagPlugin()],
   formatError: (error) => {
-    console.error(get(error, 'extensions.exception.stacktrace').join('\n'));
+    console.error(get(error, 'extensions.exception.stacktrace', []).join('\n'));
     return error;
   },
   playground: {


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**
