### PR TITLE
Adds postinstall at root

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ios": "lerna run ios --parallel",
     "android": "lerna run android --parallel",
     "pods": "lerna run pods --parallel",
+    "postinstall": "lerna run postinstall --parallel",
     "bump": "yarn unlink-packages && ./scripts/bump.sh",
     "canary": "./scripts/add-packages.sh canary && yarn",
     "next": "./scripts/add-packages.sh next && yarn",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "setup": "lerna run setup",
     "start": "yarn watch:client & lerna run start:dev --parallel",
     "watch:client": "(cd apolloschurchapp && yarn wml start)",
-    "link-packages": "watchman watch-del-all && yarn && lerna run link-packages --parallel && (cd apollos-church-api && yalc update)",
+    "link-packages": "watchman watch-del-all && yarn && yarn postinstall && lerna run link-packages --parallel && (cd apollos-church-api && yalc update)",
     "link-doctor": "node ./scripts/link-doctor.js",
     "unlink-packages": "lerna run unlink-packages --parallel && yarn --check-files",
     "lint": "lerna run lint --stream",


### PR DESCRIPTION
This will run the postinstall scripts for each of the directories when running yarn from the root. Makes dev a little smoother
