### PR TITLE
fix: More fine grained cache hydration signals

### DIFF
--- a/apolloschurchapp/src/client/index.js
+++ b/apolloschurchapp/src/client/index.js
@@ -14,6 +14,7 @@ import { resolvers, schema, defaults } from '../store';
 import httpLink from './httpLink';
 import cache, { ensureCacheHydration } from './cache';
 import MARK_CACHE_LOADED from './markCacheLoaded';
+import MARK_CACHE_LOADING from './markCacheLoading';
 
 const goToAuth = () => NavigationService.resetToAuth();
 const wipeData = () => cache.writeData({ data: defaults });

--- a/apolloschurchapp/src/client/markCacheLoading.js
+++ b/apolloschurchapp/src/client/markCacheLoading.js
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation markCacheLoading {
+    cacheMarkLoading @client
+  }
+`;

--- a/apolloschurchapp/src/store/index.js
+++ b/apolloschurchapp/src/store/index.js
@@ -16,6 +16,7 @@ export const schema = `
 
   type Mutation {
     cacheMarkLoaded
+    cacheMarkLoading
     updateDevicePushId(pushId: String!)
     updatePushPermissions(enabled: Boolean!)
   }
@@ -35,6 +36,14 @@ const GET_LOGGED_IN = gql`
 
 export const resolvers = {
   Mutation: {
+    cacheMarkLoading: (root, args, { cache }) => {
+      cache.writeQuery({
+        query: CACHE_LOADED,
+        data: {
+          cacheLoaded: false,
+        },
+      });
+    },
     cacheMarkLoaded: async (root, args, { cache, client }) => {
       cache.writeQuery({
         query: CACHE_LOADED,


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**
