### PR TITLE
feat: Set apollos user to true on login

### DIFF
--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -47,10 +47,6 @@ import {
 
 import * as Theme from './theme';
 
-// This module is used to attach Rock User updating to the OneSignal module.
-// This module includes a Resolver that overides a resolver defined in `OneSignal`
-import * as OneSignalWithRock from './oneSignalWithRock';
-
 // This modules ties together certain updates so they occurs in both Rock and Postgres.
 // Will be eliminated in the future through an enhancement to the Shovel
 import * as Person from './rockWithPostgres';
@@ -76,7 +72,6 @@ const data = {
   Analytics,
   OneSignal,
   PersonalDevice,
-  OneSignalWithRock,
   Pass,
   Search,
   Template,

--- a/apollos-church-api/src/data/rockWithPostgres.js
+++ b/apollos-church-api/src/data/rockWithPostgres.js
@@ -74,7 +74,6 @@ export const resolver = {
             value: true,
           },
         ]);
-        console.log('setting apollos user');
       } catch (e) {
         console.warn(e);
       }

--- a/apollos-church-api/src/data/rockWithPostgres.js
+++ b/apollos-church-api/src/data/rockWithPostgres.js
@@ -56,5 +56,31 @@ export const resolver = {
         { field: 'campusId', value: campus.id },
       ]); // updates in Postgres
     },
+    updateUserPushSettings: async (root, { input }, { dataSources }) => {
+      // register the changes w/ one signal
+      const returnValue = await dataSources.OneSignal.updatePushSettings(input);
+
+      // if the pushProviderUserId is changing, we need ot register the device with rock.
+      if (input.pushProviderUserId != null) {
+        await dataSources.PersonalDevice.addPersonalDevice({
+          pushId: input.pushProviderUserId,
+        });
+      }
+
+      try {
+        await dataSources.Person.updateProfile([
+          {
+            field: 'apollosUser',
+            value: true,
+          },
+        ]);
+        console.log('setting apollos user');
+      } catch (e) {
+        console.warn(e);
+      }
+
+      // return the original return value (which is currentPerson)
+      return returnValue;
+    },
   },
 };


### PR DESCRIPTION
This will tag users as apollos users when they open the app, login, and register. Not a great long term solution, but it should work very well for our needs right now. 