### PR TITLE
Add package only adds updated packages

### DIFF
--- a/scripts/add-packages.js
+++ b/scripts/add-packages.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const { execSync, exec } = require('child_process');
+
+const semver = require(`semver`);
+
+const tag = process.argv[2];
+const force = process.argv[3];
+
+if (!tag) {
+  console.warn('Usage: ./add-packages.sh <TAG>');
+}
+
+const packageJson = JSON.parse(fs.readFileSync(`${process.env.PWD}/package.json`));
+
+const dependencies = [...Object.keys(packageJson.dependencies)]
+  .filter(
+    (d) =>
+      d.includes('@apollosproject') && !d.includes('react-native-airplay-btn')
+  )
+  .map((key) => ({
+    pkg: key,
+    version: semver.coerce(packageJson.dependencies[key]),
+  }));
+
+const devDepenencies = [...Object.keys(packageJson.devDependencies)]
+  .filter(
+    (d) =>
+      d.includes('@apollosproject') && !d.includes('react-native-airplay-btn')
+  )
+  .map((key) => ({
+    pkg: key,
+    version: semver.coerce(packageJson.devDependencies[key]),
+  }));
+
+const filterDependencies = (deps) =>
+  Promise.all(
+    deps.map(
+      (dep) =>
+        new Promise((resolve) => {
+          exec(
+            `npm dist-tag ${dep.pkg}@${tag}`,
+            { encoding: 'utf8' },
+            (err, tags) => {
+              const currentTagMatch = tags.match(new RegExp(`${tag}: (.*)`));
+              const currentTagVersion = semver.coerce(currentTagMatch[1]);
+              const shouldUpdate = semver.gt(currentTagVersion, dep.version);
+              resolve({ shouldUpdate, pkg: dep.pkg });
+            }
+          );
+        })
+    )
+  );
+
+(async () => {
+  console.log('Evaluating packages to update...');
+  let depsToUpdate = [];
+  let devDepsToUpdate = [];
+  // Filter out packages who would be downgraded by updating to the latest tag.
+  if (!force) {
+    const deps = await filterDependencies(dependencies);
+    const devDeps = await filterDependencies(devDepenencies);
+
+    depsToUpdate = deps.filter(({ shouldUpdate }) => shouldUpdate);
+    devDepsToUpdate = devDeps.filter(({ shouldUpdate }) => shouldUpdate);
+  }
+  console.log(`Updating the following packages`);
+  const updateString = depsToUpdate.map(({ pkg }) => `${pkg}@${tag}`).join(' ');
+  console.log(updateString);
+
+  console.log('Updating the following dev deps');
+  const devUpdateString = devDepsToUpdate
+    .map(({ pkg }) => `${pkg}@${tag}`)
+    .join(' ');
+  console.log(devUpdateString);
+
+  if (depsToUpdate.length) {
+    const output = execSync(`yarn add ${updateString} --ignore-scripts`, {
+      encoding: 'utf8',
+    });
+    console.log(output);
+  }
+
+  if (devDepsToUpdate.length) {
+    const devOutput = execSync(
+      `yarn add --dev ${devUpdateString} --ignore-scripts`,
+      { encoding: 'utf8' }
+    );
+    console.log(devOutput);
+  }
+})();

--- a/scripts/add-packages.js
+++ b/scripts/add-packages.js
@@ -43,7 +43,7 @@ const filterDependencies = (deps) =>
             (err, tags) => {
               const currentTagMatch = tags.match(new RegExp(`${tag}: (.*)`));
               const currentTagVersion = semver.coerce(currentTagMatch[1]);
-              const shouldUpdate = semver.gt(currentTagVersion, dep.version);
+              const shouldUpdate = semver.gte(currentTagVersion, dep.version);
               resolve({ shouldUpdate, pkg: dep.pkg });
             }
           );

--- a/scripts/add-packages.sh
+++ b/scripts/add-packages.sh
@@ -1,38 +1,9 @@
-# get list of apollosproject packages to update
-function add() {
-	# get devDependencies line number
-	DEVDEPSLINE=$(grep -n "devDependencies" package.json | sed -E "s/^([0-9]+):.*/\1/g")
-
-	# get dependecies line number
-	DEPSLINE=$(grep -n "dependencies" package.json | sed -E "s/^([0-9]+):.*/\1/g")
-
-	# replace package names with version tag
-	JSON=$(sed -E "s/^.*\"(@apollosproject\/[a-z\-]+)\".*/\1@$1 /g" package.json)
-
-	# remove packages with no tags
-	JSON=$( echo "$JSON" | sed "s/@apollosproject\/react-native-airplay-btn.*//g")
-
-	# if packages are listed first and dev packages second...
-	if [ $DEVDEPSLINE -gt $DEPSLINE ]
-	then
-			PKGS=$(echo "$JSON" | sed -n "$DEPSLINE","$DEVDEPSLINE"p | grep "@apollosproject" | tr -d "\n")
-			DEVPKGS=$(echo "$JSON" | sed -n "$DEVDEPSLINE",/^$/p | grep "@apollosproject" | tr -d "\n")
-	else
-			PKGS=$(echo "$JSON" | sed -n "$DEPSLINE",/^$/p | grep "@apollosproject" | tr -d "\n")
-			DEVPKGS=$(echo "$JSON" | sed -n "$DEVDEPSLINE","$DEPSLINE"p | grep "@apollosproject" | tr -d "\n")
-	fi
-
-	yarn add --dev $DEVPKGS --ignore-scripts
-	yarn add $PKGS --ignore-scripts
-}
-
-# determine what npm tag to update to
 if [ "$#" -ne 1 ]; then
-	echo "Usage: ./add-packages.sh <TAG>"
-	exit
+  echo "Usage: ./add-packages.sh <TAG>"
+  exit
 else
-	TAG=$1
+  TAG=$1
 fi;
 
-(cd apollos-church-api && add $TAG)
-(cd apolloschurchapp && add $TAG)
+(cd apollos-church-api && NODE_PATH='./node_modules' node ../scripts/add-packages.js $TAG)
+(cd apolloschurchapp && NODE_PATH='./node_modules' node ../scripts/add-packages.js $TAG)


### PR DESCRIPTION
My shell foo is bad so I rewrote the script in node. 

The script goes and compares the current package.json version with the version of the tag. It only updates the packages if the tag version is greater. 

This fixes an issue where I was going in and having to manually update most packages to the latest stable version every time I ran `yarn canary`, since most canary packages aren't updated every release (they would get bumped to an older release when running yarn canary) 

The script might take a wee bit longer if all the packages need updating, but in my testing it actually takes way less time since most of the time only a few packages need to be updated at once. 