### PR TITLE
removes datetime picker from deps

### DIFF
--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -100,7 +100,6 @@
     "react-native-inappbrowser-reborn": "^3.0.0",
     "react-native-linear-gradient": "^2.5.4",
     "react-native-maps": "^0.27.1",
-    "react-native-modal-datetime-picker": "9.0.0",
     "react-native-music-control": "0.10.8",
     "react-native-onesignal": "3.9.1",
     "react-native-passkit-wallet": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13807,13 +13807,6 @@ react-native-modal-datetime-picker@8.7.1:
   dependencies:
     prop-types "^15.7.2"
 
-react-native-modal-datetime-picker@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-9.0.0.tgz#43da27d777337d5ad5045b1538d3d5b5b197a968"
-  integrity sha512-8856SLrlVokhBaNWQmkwKbrwjfZP0AfRFIaA4CGXtXq83Hd+mvdmGbwKSfrAGQspAsqFMi7CYxSf4s0n16xCeg==
-  dependencies:
-    prop-types "^15.7.2"
-
 react-native-music-control@0.10.8:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/react-native-music-control/-/react-native-music-control-0.10.8.tgz#72272bf9cb1fc0142dc38c99e5f2142fece3c37a"


### PR DESCRIPTION
This isn't a native module so it doesn't need to be included here
