### PR TITLE
Move providers inside nav stack

### DIFF
--- a/apolloschurchapp/ios/Podfile.lock
+++ b/apolloschurchapp/ios/Podfile.lock
@@ -613,7 +613,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
@@ -624,7 +624,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OneSignal: e4dfb1912410f302dc9661ce98fc829f6c18ff6a
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b

--- a/apolloschurchapp/src/Providers.js
+++ b/apolloschurchapp/src/Providers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ApollosConfig from '@apollosproject/config';
 import { NavigationService } from '@apollosproject/ui-kit';
 import { AuthProvider } from '@apollosproject/ui-auth';
@@ -55,5 +56,9 @@ const AppProviders = (props) => (
     </NotificationsProvider>
   </ClientProvider>
 );
+
+AppProviders.propTypes = {
+  children: PropTypes.shape({}),
+};
 
 export default AppProviders;

--- a/apolloschurchapp/src/Providers.js
+++ b/apolloschurchapp/src/Providers.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ApollosConfig from '@apollosproject/config';
-import { Providers, NavigationService } from '@apollosproject/ui-kit';
+import { NavigationService } from '@apollosproject/ui-kit';
 import { AuthProvider } from '@apollosproject/ui-auth';
 import { AnalyticsProvider } from '@apollosproject/ui-analytics';
 import { NotificationsProvider } from '@apollosproject/ui-notifications';
@@ -11,7 +11,6 @@ import {
 import { checkOnboardingStatusAndNavigate } from '@apollosproject/ui-onboarding';
 
 import ClientProvider, { client } from './client';
-import customTheme, { customIcons } from './theme';
 
 const AppProviders = (props) => (
   <ClientProvider {...props}>
@@ -50,13 +49,7 @@ const AppProviders = (props) => (
         }
       >
         <AnalyticsProvider>
-          <LiveProvider>
-            <Providers
-              themeInput={customTheme}
-              iconInput={customIcons}
-              {...props}
-            />
-          </LiveProvider>
+          <LiveProvider>{props.children}</LiveProvider>
         </AnalyticsProvider>
       </AuthProvider>
     </NotificationsProvider>

--- a/apolloschurchapp/src/index.js
+++ b/apolloschurchapp/src/index.js
@@ -17,6 +17,7 @@ import {
   BackgroundView,
   withTheme,
   NavigationService,
+  Providers as ThemeProvider,
 } from '@apollosproject/ui-kit';
 import Passes from '@apollosproject/ui-passes';
 import { MapViewConnected as Location } from '@apollosproject/ui-mapview';
@@ -32,6 +33,7 @@ import ContentSingle from './content-single';
 import Event from './event';
 import Tabs from './tabs';
 import LandingScreen from './ui/LandingScreen';
+import customTheme, { customIcons } from './theme';
 
 enableScreens(); // improves performance for react-navigation
 
@@ -71,67 +73,73 @@ const ThemedNavigationContainer = withTheme(({ theme, ...props }) => ({
 const { Navigator, Screen } = createNativeStackNavigator();
 
 const App = () => (
-  <Providers>
+  <ThemeProvider themeInput={customTheme} iconInput={customIcons}>
     <BackgroundView>
       <AppStatusBar />
       <ThemedNavigationContainer
         containerRef={NavigationService.setTopLevelNavigator}
         onReady={NavigationService.setIsReady}
       >
-        <Navigator
-          screenOptions={{ headerShown: false, stackPresentation: 'modal' }}
-        >
-          <Screen
-            name="ProtectedRoute"
-            component={ProtectedRouteWithSplashScreen}
-          />
-          <Screen name="Tabs" component={Tabs} />
-          <Screen
-            name="ContentSingle"
-            component={ContentSingle}
-            options={{
-              title: 'Content',
-              stackPresentation: 'push',
-            }}
-          />
-          <Screen
-            component={ContentFeedConnected}
-            name="ContentFeed"
-            options={({ route }) => ({
-              title: route.params.itemTitle || 'Content Feed',
-              stackPresentation: 'push',
-            })}
-          />
+        <Providers>
+          <Navigator
+            screenOptions={{ headerShown: false, stackPresentation: 'modal' }}
+          >
+            <Screen
+              name="ProtectedRoute"
+              component={ProtectedRouteWithSplashScreen}
+            />
+            <Screen name="Tabs" component={Tabs} />
+            <Screen
+              name="ContentSingle"
+              component={ContentSingle}
+              options={{
+                title: 'Content',
+                stackPresentation: 'push',
+              }}
+            />
+            <Screen
+              component={ContentFeedConnected}
+              name="ContentFeed"
+              options={({ route }) => ({
+                title: route.params.itemTitle || 'Content Feed',
+                stackPresentation: 'push',
+              })}
+            />
 
-          <Screen name="Event" component={Event} options={{ title: 'Event' }} />
-          <Screen
-            name="Auth"
-            component={Auth}
-            options={{
-              gestureEnabled: false,
-              stackPresentation: 'push',
-            }}
-          />
-          <Screen name="Location" component={Location} />
-          <Screen
-            name="Passes"
-            component={Passes}
-            options={{ title: 'Check-In Pass' }}
-          />
-          <Screen
-            name="Onboarding"
-            component={Onboarding}
-            options={{
-              gestureEnabled: false,
-              stackPresentation: 'push',
-            }}
-          />
-          <Screen name="LandingScreen" component={LandingScreen} />
-          <Screen name="Search" component={SearchScreenConnected} />
-        </Navigator>
+            <Screen
+              name="Event"
+              component={Event}
+              options={{ title: 'Event' }}
+            />
+            <Screen
+              name="Auth"
+              component={Auth}
+              options={{
+                gestureEnabled: false,
+                stackPresentation: 'push',
+              }}
+            />
+            <Screen name="Location" component={Location} />
+            <Screen
+              name="Passes"
+              component={Passes}
+              options={{ title: 'Check-In Pass' }}
+            />
+            <Screen
+              name="Onboarding"
+              component={Onboarding}
+              options={{
+                gestureEnabled: false,
+                stackPresentation: 'push',
+              }}
+            />
+            <Screen name="LandingScreen" component={LandingScreen} />
+            <Screen name="Search" component={SearchScreenConnected} />
+          </Navigator>
+        </Providers>
       </ThemedNavigationContainer>
     </BackgroundView>
-  </Providers>
+  </ThemeProvider>
 );
 
 export default App;


### PR DESCRIPTION
You can test with `xcrun simctl openurl booted apolloschurchapp://app-link/content/UniversalContentItem:6ce6ad8948489bb984c3cb7ffaa0129a`

I'm pushing off deleting `NavigationService` since this PR fixes a critical-ish bug. I'll fast follow with that PR. 