### PR TITLE
fix: added a divider below Change Password in the Settings Tab

### DIFF
--- a/apolloschurchapp/src/user-settings/__snapshots__/UserSettings.tests.js.snap
+++ b/apolloschurchapp/src/user-settings/__snapshots__/UserSettings.tests.js.snap
@@ -1152,6 +1152,14 @@ exports[`UserSettings component renders UserSettings when logged in 1`] = `
                             </View>
                           </View>
                           <View
+                            style={
+                              Object {
+                                "backgroundColor": "rgba(0, 0, 0, 0.09999999999999998)",
+                                "height": 0.5,
+                              }
+                            }
+                          />
+                          <View
                             accessible={true}
                             focusable={true}
                             onClick={[Function]}

--- a/apolloschurchapp/src/user-settings/index.js
+++ b/apolloschurchapp/src/user-settings/index.js
@@ -86,6 +86,7 @@ const UserSettings = () => {
                     <CellIcon name="arrow-next" />
                   </Cell>
                 </Touchable>
+                <Divider />
                 <Touchable
                   onPress={() => {
                     navigation.navigate('Notifications');


### PR DESCRIPTION
Realized that this change was coming from templates. There was a missing divider on the Settings Tab.