### PR TITLE
safer database content opt in

### DIFF
--- a/apollos-church-api/src/config.js
+++ b/apollos-church-api/src/config.js
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import path from 'path';
 import fetch from 'node-fetch';
 import dotenv from "dotenv/config"; // eslint-disable-line
@@ -8,7 +7,7 @@ ApollosConfig.loadYaml({
   configPath: path.join(
     __dirname,
     '..',
-    fs.existsSync(path.join(__dirname, '..', 'config.postgres.yml'))
+    process.env.DATABASE_CONTENT === 'true'
       ? 'config.postgres.yml'
       : 'config.yml'
   ),

--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -1,5 +1,3 @@
-import fs from 'fs';
-import path from 'path';
 import { gql } from 'apollo-server';
 
 import {

--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -90,7 +90,7 @@ const data = {
   RockPerson, // This entry needs to come before (postgres) Person
   BinaryFiles, // This entry needs to come before (postgres) Person
   PostgresPerson, // Postgres person for now, as we extend this dataSource in the 'rockWithPostgres' file
-  ...(fs.existsSync(path.join(__dirname, '../..', 'config.postgres.yml'))
+  ...(process.env.DATABASE_CONTENT
     ? postgresContentModules
     : rockContentModules),
   Cloudinary,


### PR DESCRIPTION
the other way doesn't work like i'd hoped with upgrades because the config file is patched from templates and then its confusing why the app isn't working. this is just temporary, soon all apps will use database content anyway, and we won't need this opt in. maybe can drop it for v3 when DB is required.
