### PR TITLE
fix: campus updating

### DIFF
--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -91,7 +91,12 @@ const rockContentModules = {
   ContentItem: RockContentItem,
   ContentChannel,
   PrayerRequest,
-  PostgresCampus: { dataSource: Campus.dataSource },
+  PostgresCampus: {
+    // essentially everything but the resolvers
+    dataSource: Campus.dataSource,
+    models: Campus.models,
+    migrations: Campus.migrations,
+  },
   Campus: RockCampus,
   RockDefaultCampusOverride,
 };


### PR DESCRIPTION
We got a little overzealous at one point, trying to fix this data connector.

You need to test with a `DATABASE_URL` but with `USE_CONTENT=false`. 

<img width="1455" alt="Screen Shot 2021-09-22 at 10 51 24 AM" src="https://user-images.githubusercontent.com/1637694/134369428-83a243cc-b931-4fee-af71-de32beaa8134.png">

```
query campuses {
  campuses(location:{latitude:45.52252, longitude:-122.67325 }) {
    id
    distanceFromLocation
    name
    state
    street1
    street2
    city
    postalCode
    latitude
    longitude
    image {
      uri
    }
  }
}

query mycampus {
  currentUser {
    profile {
      campus {
        id
        name
        city
        state
      }
    }
  }
}

mutation setCampus {
  updateUserCampus(campusId:"Campus:4f68015ba18662a7409d1219a4ce013e") {
    id
    campus {
      id
      city
      state
    }
  }
}
```