### PR TITLE
chore: downgrade ndk version to fix android deploys failing

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -141,6 +141,8 @@ configurations.all {
 }
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
+        ndkVersion = "18.1.5063045"
     }
     repositories {
         google()


### PR DESCRIPTION
By downgrading the ndk version, we have been able to get Android deploys working again. This issue was affecting several Apollos apps.