### PR TITLE
turns off automatic release

### DIFF
--- a/apolloschurchapp/fastlane/Fastfile
+++ b/apolloschurchapp/fastlane/Fastfile
@@ -63,10 +63,10 @@ platform :ios do
     app_store_connect_api_key(key_filepath: "ios/apollos.p8", in_house: false)
     deliver(
       skip_binary_upload: true,
-      skip_screenshots: true,
-      skip_metadata: true,
+      skip_screenshots: false,
+      skip_metadata: false,
       submit_for_review: true,
-      automatic_release: true,
+      automatic_release: false,
       submission_information: {
         add_id_info_uses_idfa: false
       },


### PR DESCRIPTION
this lets us upload screenshots and metadata from the terminal at first on new apps and then can flip that bit once we feel good about releaes
